### PR TITLE
Fix bug, add command, and RFC: drop lock.

### DIFF
--- a/dead_test.go
+++ b/dead_test.go
@@ -1,0 +1,24 @@
+package ptrace
+import "syscall"
+import "testing"
+
+func TestDiedThenStep(t *testing.T) {
+  tracee, err := Exec("/bin/true", []string{"/bin/true"})
+  if err != nil {
+    t.Fatalf("could not start process: %v\n", err)
+    t.FailNow()
+  }
+  if err := tracee.Continue() ; err != nil {
+    t.Fatalf("continuing failed: %v\n", err)
+    t.FailNow()
+  }
+  stat := <- tracee.Events()
+  if stat.(syscall.WaitStatus).Exited() {
+		/* This *should* produce an error. */
+    err := tracee.SingleStep()
+    if err == nil {
+      t.Fatalf("single stepping post-exit did not produce error!")
+    }
+    return
+  }
+}

--- a/ptrace.go
+++ b/ptrace.go
@@ -188,6 +188,21 @@ func (t *Tracee) WriteWord(address uintptr, word uint64) (error) {
 	return errors.New("unreachable.")
 }
 
+// read the registers from the inferior.
+func (t* Tracee) GetRegs() (syscall.PtraceRegs, error) {
+	errchan := make(chan error, 1)
+	value := make(chan syscall.PtraceRegs, 1)
+	if t.do(func() {
+		var regs syscall.PtraceRegs
+		err := syscall.PtraceGetRegs(t.proc.Pid, &regs)
+		value <- regs
+		errchan <- err
+	}) {
+		return <-value, <-errchan
+	}
+	return syscall.PtraceRegs{}, errors.New("unreachable.")
+}
+
 // reads the instruction pointer from the inferior and returns it.
 func (t* Tracee) GetIPtr() (uintptr, error) {
 	errchan := make(chan error, 1)

--- a/ptrace.go
+++ b/ptrace.go
@@ -97,6 +97,18 @@ func (t *Tracee) SingleStep() error {
 	return TraceeExited
 }
 
+// Makes the tracee execute unmanaged by the tracer.  Most commands are not
+// possible in this state, with the notable exception of sending a
+// syscall.SIGSTOP signal.
+func (t *Tracee) Continue() error {
+	err := make(chan error, 1)
+	sig := 0
+	if t.do(func() { err <- syscall.PtraceCont(t.proc.Pid, sig) }) {
+		return <-err
+	}
+	return TraceeExited
+}
+
 // Sends the command to the tracer go routine.  Returns whether the command
 // was sent or not.  The command may not have been sent if the tracee exited.
 func (t *Tracee) do(f func()) bool {

--- a/ptrace.go
+++ b/ptrace.go
@@ -209,6 +209,7 @@ func (t* Tracee) GetIPtr() (uintptr, error) {
 	value := make(chan uintptr, 1)
 	if t.do(func() {
 		var regs syscall.PtraceRegs
+		regs.Rip = 0
 		err := syscall.PtraceGetRegs(t.proc.Pid, &regs)
 		value <- uintptr(regs.Rip)
 		errchan <- err

--- a/ptrace.go
+++ b/ptrace.go
@@ -26,6 +26,8 @@ type Tracee struct {
 	cmds chan func()
 }
 
+func (t *Tracee) PID() int { return t.proc.Pid }
+
 // Events returns the events channel for the tracee.
 func (t *Tracee) Events() <-chan Event {
 	return t.events

--- a/ptrace.go
+++ b/ptrace.go
@@ -203,6 +203,20 @@ func (t* Tracee) GetIPtr() (uintptr, error) {
 	return 0, errors.New("unreachable.")
 }
 
+func (t* Tracee) SetIPtr(addr uintptr) error {
+	errchan := make(chan error, 1)
+	if t.do(func() {
+		var regs syscall.PtraceRegs
+		err := syscall.PtraceGetRegs(t.proc.Pid, &regs)
+		if err != nil { errchan <- err; return }
+		err = syscall.PtraceSetRegs(t.proc.Pid, &regs)
+		errchan <- err
+	}) {
+		return <-errchan
+	}
+	return errors.New("unreachable")
+}
+
 // Sends the command to the tracer go routine.	Returns whether the command
 // was sent or not. The command may not have been sent if the tracee exited.
 func (t *Tracee) do(f func()) bool {

--- a/ptrace.go
+++ b/ptrace.go
@@ -109,6 +109,15 @@ func (t *Tracee) Continue() error {
 	return TraceeExited
 }
 
+// Sends the given signal to the tracee.
+func (t *Tracee) SendSignal(sig syscall.Signal) error {
+	err := make(chan error, 1)
+	if t.do(func() { err <- syscall.Kill(t.proc.Pid, sig) }) {
+		return <-err
+	}
+	return nil
+}
+
 // Sends the command to the tracer go routine.  Returns whether the command
 // was sent or not.  The command may not have been sent if the tracee exited.
 func (t *Tracee) do(f func()) bool {

--- a/ptrace.go
+++ b/ptrace.go
@@ -209,6 +209,7 @@ func (t* Tracee) SetIPtr(addr uintptr) error {
 		var regs syscall.PtraceRegs
 		err := syscall.PtraceGetRegs(t.proc.Pid, &regs)
 		if err != nil { errchan <- err; return }
+		regs.Rip = uint64(addr)
 		err = syscall.PtraceSetRegs(t.proc.Pid, &regs)
 		errchan <- err
 	}) {

--- a/ptrace/dead_test.go
+++ b/ptrace/dead_test.go
@@ -1,0 +1,1 @@
+../dead_test.go

--- a/ptrace/ptrace.go
+++ b/ptrace/ptrace.go
@@ -1,0 +1,1 @@
+../ptrace.go

--- a/ptrace/rdword_test.go
+++ b/ptrace/rdword_test.go
@@ -1,0 +1,22 @@
+package ptrace
+import "testing"
+
+func TestReadingWord(t *testing.T) {
+	tracee, err := Exec("/bin/true", []string{"/bin/true"})
+	if err != nil {
+		t.Fatalf("could not start process: %v\n", err)
+		t.FailNow()
+	}
+	// ugh.	0x00400000 is specific to linux/amd64.
+	wd, err := tracee.ReadWord(0x00400000)
+	
+	if err != nil {
+		t.Fatalf("could not read first word of program image: %v\n", err)
+	}
+	// The first word of the binary image should be the file's magic.
+	magic := 0x00000000FFFFFFFF & wd
+	// .. and since we're assuming linux, that magic is {0x7f,'E','L','F'}
+	if magic != 0x464c457f {
+		t.Fatalf("magic does not match! 0x%x\n", magic)
+	}
+}

--- a/ptrace/register_test.go
+++ b/ptrace/register_test.go
@@ -18,3 +18,15 @@ func TestReadingInstructionPointer(t *testing.T) {
   }
   tracee.SendSignal(syscall.SIGKILL)
 }
+
+func TestSetInstructionPointer(t *testing.T) {
+	tracee, err := Exec("/bin/true", []string{"/bin/true"})
+	if err != nil {
+		t.Fatalf("could not start process: %v\n", err)
+		t.FailNow()
+	}
+	<- tracee.Events() // wait for tracee to start.
+	err = tracee.SetIPtr(0x00400000)
+  if err != nil { t.Fatalf("set iptr error: %v\n", err) }
+  tracee.SendSignal(syscall.SIGKILL)
+}

--- a/ptrace/register_test.go
+++ b/ptrace/register_test.go
@@ -28,5 +28,12 @@ func TestSetInstructionPointer(t *testing.T) {
 	<- tracee.Events() // wait for tracee to start.
 	err = tracee.SetIPtr(0x00400000)
   if err != nil { t.Fatalf("set iptr error: %v\n", err) }
+
+	iptr, err := tracee.GetIPtr()
+  if err != nil { t.Fatalf("get iptr error: %v\n", err) }
+
+	if iptr != 0x00400000 {
+		t.Fatalf("iptr set 0x%x instead of 0x00400000\n", iptr)
+	}
   tracee.SendSignal(syscall.SIGKILL)
 }

--- a/ptrace/register_test.go
+++ b/ptrace/register_test.go
@@ -1,0 +1,20 @@
+package ptrace
+import "syscall"
+import "testing"
+
+func TestReadingInstructionPointer(t *testing.T) {
+	tracee, err := Exec("/bin/true", []string{"/bin/true"})
+	if err != nil {
+		t.Fatalf("could not start process: %v\n", err)
+		t.FailNow()
+	}
+  iptr, err := tracee.GetIPtr()
+  if err != nil { t.Fatalf("iptr error: %v\n", err) }
+  // 0x00400000 is linux/amd64's entry point.  it would be absurd if the iptr
+  // was less than that, since it couldn't have gotten far (or even anywhere)
+  // since it began.
+  if iptr < 0x00400000 {
+    t.Fatalf("instruction pointer is too small: 0x%x\n", iptr)
+  }
+  tracee.SendSignal(syscall.SIGKILL)
+}

--- a/ptrace/register_test.go
+++ b/ptrace/register_test.go
@@ -56,6 +56,9 @@ func TestGrabRegs(t *testing.T) {
 
 	registers, err := tracee.GetRegs()
 	if err != nil { t.Fatalf("get registers error: %v\n", err) }
+	if registers.Rip == 0x0 {
+		t.Fatalf("instruction pointer is nonsense.\n")
+	}
 
 	tracee.SendSignal(syscall.SIGKILL)
 }

--- a/ptrace/register_test.go
+++ b/ptrace/register_test.go
@@ -8,15 +8,15 @@ func TestReadingInstructionPointer(t *testing.T) {
 		t.Fatalf("could not start process: %v\n", err)
 		t.FailNow()
 	}
-  iptr, err := tracee.GetIPtr()
-  if err != nil { t.Fatalf("iptr error: %v\n", err) }
-  // 0x00400000 is linux/amd64's entry point.  it would be absurd if the iptr
-  // was less than that, since it couldn't have gotten far (or even anywhere)
-  // since it began.
-  if iptr < 0x00400000 {
-    t.Fatalf("instruction pointer is too small: 0x%x\n", iptr)
-  }
-  tracee.SendSignal(syscall.SIGKILL)
+	iptr, err := tracee.GetIPtr()
+	if err != nil { t.Fatalf("iptr error: %v\n", err) }
+	// 0x00400000 is linux/amd64's entry point.  it would be absurd if the iptr
+	// was less than that, since it couldn't have gotten far (or even anywhere)
+	// since it began.
+	if iptr < 0x00400000 {
+		t.Fatalf("instruction pointer is too small: 0x%x\n", iptr)
+	}
+	tracee.SendSignal(syscall.SIGKILL)
 }
 
 func TestSetInstructionPointer(t *testing.T) {
@@ -27,10 +27,10 @@ func TestSetInstructionPointer(t *testing.T) {
 	}
 	<- tracee.Events() // wait for tracee to start.
 	err = tracee.SetIPtr(0x00400000)
-  if err != nil { t.Fatalf("set iptr error: %v\n", err) }
+	if err != nil { t.Fatalf("set iptr error: %v\n", err) }
 
 	iptr, err := tracee.GetIPtr()
-  if err != nil { t.Fatalf("get iptr error: %v\n", err) }
+	if err != nil { t.Fatalf("get iptr error: %v\n", err) }
 
 	if iptr != 0x00400000 {
 		t.Fatalf("iptr set 0x%x instead of 0x00400000\n", iptr)

--- a/ptrace/wrword_test.go
+++ b/ptrace/wrword_test.go
@@ -10,7 +10,7 @@ func TestWritingWord(t *testing.T) {
 	// ugh.	0x00400000 is specific to linux/amd64.
 	_, err = tracee.ReadWord(0x00400000)
 	if err != nil {
-    t.Fatalf("could not read first word of program image: %v\n", err)
+		t.Fatalf("could not read first word of program image: %v\n", err)
 	}
 	err = tracee.WriteWord(0x00400000, 0xCCccCCccCCccCCcc)
 	if err != nil { t.Fatalf("%v\n", err) }

--- a/ptrace/wrword_test.go
+++ b/ptrace/wrword_test.go
@@ -1,0 +1,17 @@
+package ptrace
+import "testing"
+
+func TestWritingWord(t *testing.T) {
+	tracee, err := Exec("/bin/true", []string{"/bin/true"})
+	if err != nil {
+		t.Fatalf("could not start process: %v\n", err)
+		t.FailNow()
+	}
+	// ugh.	0x00400000 is specific to linux/amd64.
+	_, err = tracee.ReadWord(0x00400000)
+	if err != nil {
+    t.Fatalf("could not read first word of program image: %v\n", err)
+	}
+	err = tracee.WriteWord(0x00400000, 0xCCccCCccCCccCCcc)
+	if err != nil { t.Fatalf("%v\n", err) }
+}


### PR DESCRIPTION
97b84f8: simply adds a new command.  Looks like the style you wanted, clue me in if not.
d6d6d0b: the process didn't exit, so don't pretend that it did.
f356bdb: RFC: I do not think we need this lock.  If the channel is closing, that implies the process no longer exists.  If the process no longer exists, it will not send us any events.  Another way: "process is finished" is by definition the last event that a tracee can give us, and thus while we are handling "process is finished" it is not possible for the tracee to send us another event.
No?
